### PR TITLE
Fix rendering of ReturnDict values

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 djangorestframework>=3.0.0
+Django>=1.8

--- a/rest_camel/util.py
+++ b/rest_camel/util.py
@@ -1,5 +1,4 @@
 import re
-from collections import OrderedDict
 
 
 def camelize_key(key, uppercase_first_letter=True):
@@ -57,8 +56,8 @@ def underscore_key(key):
 def camelize(data):
     data_type = type(data)
 
-    if data_type in (dict, OrderedDict):
-        new_dict = data_type()
+    if isinstance(data, dict):
+        new_dict = copy_dict(data)
         for k, v in data.items():
             new_dict[camelize_key(k, False)] = camelize(v)
 
@@ -73,8 +72,8 @@ def camelize(data):
 def underscorize(data):
     data_type = type(data)
 
-    if data_type in (data, dict):
-        new_dict = data_type()
+    if isinstance(data, dict):
+        new_dict = copy_dict(data)
         for key, value in data.items():
             new_dict[underscore_key(key)] = underscorize(value)
         return new_dict
@@ -83,3 +82,18 @@ def underscorize(data):
         return type(data)(underscorize(x) for x in data)
 
     return data
+
+
+def copy_dict(data):
+    """
+    copy() dict data type and clear it afterwards.
+    DRF ReturnDict holds onto a serializer is must be set if initializing a
+    new object. copy() takes care of that.
+
+    :param data: dictionary type
+    :return: copied and cleared dictionary
+    """
+    # Support DRF ReturnDict
+    new_dict = data.copy()
+    new_dict.clear()
+    return new_dict

--- a/tests.py
+++ b/tests.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from django.conf import settings
+settings.configure(DEBUG=True)
+
 from unittest.case import TestCase
 
+from rest_framework.utils.serializer_helpers import ReturnDict
 from rest_camel.util import camelize, underscorize
 
 
@@ -12,6 +16,19 @@ class UnderscoreToCamelTestCase(TestCase):
         input = {
             "title_display": 1
         }
+        output = {
+            "titleDisplay": 1
+        }
+        result = camelize(input)
+        self.assertEqual(result, output)
+        self.assertIsNot(result, input, "should not change original dict")
+
+    def test_return_dict_under_to_camel_dict(self):
+        stub_serializer = object()
+        input_raw = {
+            "title_display": 1
+        }
+        input = ReturnDict(input_raw, serializer=stub_serializer)
         output = {
             "titleDisplay": 1
         }
@@ -54,6 +71,21 @@ class UnderscoreToCamelTestCase(TestCase):
         }
         self.assertEqual(camelize(input), output)
 
+    def test_return_dict_under_to_camel_nested(self):
+        stub_serializer = object()
+        input_raw = {
+            "title_display": 1,
+            "a_list": [1, "two_three", {"three_four": 5}],
+            "a_tuple": ("one_two", 3)
+        }
+        input = ReturnDict(input_raw, serializer=stub_serializer)
+        output = {
+            "titleDisplay": 1,
+            "aList": [1, "two_three", {"threeFour": 5}],
+            "aTuple": ("one_two", 3)
+        }
+        self.assertEqual(camelize(input), output)
+
     def test_tuples(self):
         input = {
             "multiple_values": (1, 2)
@@ -78,6 +110,19 @@ class CamelToUnderscoreTestCase(TestCase):
         input = {
             "titleDisplay": 1
         }
+        output = {
+            "title_display": 1
+        }
+        result = underscorize(input)
+        self.assertEqual(result, output)
+        self.assertIsNot(result, input, "should not change original dict")
+
+    def test_return_dict_camel_to_under_dict(self):
+        stub_serializer = object()
+        input_raw = {
+            "titleDisplay": 1
+        }
+        input = ReturnDict(input_raw, serializer=stub_serializer)
         output = {
             "title_display": 1
         }
@@ -113,6 +158,21 @@ class CamelToUnderscoreTestCase(TestCase):
             "aList": [1, "two_three", {"threeFour": 5}],
             "aTuple": ("one_two", 3)
         }
+        output = {
+            "title_display": 1,
+            "a_list": [1, "two_three", {"three_four": 5}],
+            "a_tuple": ("one_two", 3)
+        }
+        self.assertEqual(underscorize(input), output)
+
+    def test_return_dict_camel_to_under_nested(self):
+        stub_serializer = object()
+        input_raw = {
+            "titleDisplay": 1,
+            "aList": [1, "two_three", {"threeFour": 5}],
+            "aTuple": ("one_two", 3)
+        }
+        input = ReturnDict(input_raw, serializer=stub_serializer)
         output = {
             "title_display": 1,
             "a_list": [1, "two_three", {"three_four": 5}],


### PR DESCRIPTION
While using rest framework 3.6.3, rendering ReturnDict failed as the type checking didn't include ReturnDict. Changed to using instance checking of dict type. When using ReturnDict, a copy() is required due to internal serializer field set on it. Finally clearing the dict to render it.

Tests for ReturnDict in underscore and camelize functions.
Added Django (1.8 or greater) to tests requirements to use ReturnDict.