### PR TITLE
Support for ReturnDict and ReturnList collections.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 djangorestframework>=3.0.0
+django>=1.8

--- a/rest_camel/util.py
+++ b/rest_camel/util.py
@@ -1,5 +1,6 @@
 import re
 from collections import OrderedDict
+from rest_framework.utils.serializer_helpers import ReturnDict, ReturnList
 
 
 def camelize_key(key, uppercase_first_letter=True):
@@ -57,15 +58,22 @@ def underscore_key(key):
 def camelize(data):
     data_type = type(data)
 
-    if data_type in (dict, OrderedDict):
-        new_dict = data_type()
+    if data_type in (dict, OrderedDict, ReturnDict):
+        kwargs = {}
+        if data_type is ReturnDict:
+            kwargs['serializer'] = data.serializer
+        new_dict = data_type(**kwargs)
+
         for k, v in data.items():
             new_dict[camelize_key(k, False)] = camelize(v)
 
         return new_dict
 
-    if data_type in (list, tuple):
-        return data_type(camelize(x) for x in data)
+    if data_type in (list, tuple, ReturnList):
+        kwargs = {}
+        if data_type is ReturnList:
+            kwargs['serializer'] = data.serializer
+        return data_type((camelize(x) for x in data), **kwargs)
 
     return data
 
@@ -73,13 +81,19 @@ def camelize(data):
 def underscorize(data):
     data_type = type(data)
 
-    if data_type in (data, dict):
-        new_dict = data_type()
+    if data_type in (dict, OrderedDict, ReturnDict):
+        kwargs = {}
+        if data_type is ReturnDict:
+            kwargs['serializer'] = data.serializer
+        new_dict = data_type(**kwargs)
         for key, value in data.items():
             new_dict[underscore_key(key)] = underscorize(value)
         return new_dict
 
-    if data_type in (list, tuple):
-        return type(data)(underscorize(x) for x in data)
+    if data_type in (list, tuple, ReturnList):
+        kwargs = {}
+        if data_type is ReturnList:
+            kwargs['serializer'] = data.serializer
+        return data_type((underscorize(x) for x in data), **kwargs)
 
     return data

--- a/tests.py
+++ b/tests.py
@@ -3,11 +3,16 @@
 
 from unittest.case import TestCase
 
+# Bootstrap django before importing anything from rest_framework.
+from django.conf import settings
+
+settings.configure()
+
 from rest_camel.util import camelize, underscorize
+from rest_framework.utils.serializer_helpers import ReturnDict, ReturnList
 
 
 class UnderscoreToCamelTestCase(TestCase):
-
     def test_under_to_camel_dict(self):
         input = {
             "title_display": 1
@@ -72,6 +77,34 @@ class UnderscoreToCamelTestCase(TestCase):
         }
         self.assertEqual(camelize(input), output)
 
+    def test_return_dict(self):
+        """
+        camelize() should convert keys in an instance of rest_framework.utils.serializer_helpers.ReturnDict
+        and keep the same serializer.
+        """
+        fake_serializer_instance = (42,)
+
+        input = ReturnDict([("title_display", 1), ("title_field", 2)], serializer=fake_serializer_instance)
+        output = ReturnDict([("titleDisplay", 1), ("titleField", 2)], serializer=fake_serializer_instance)
+
+        result = camelize(input)
+        self.assertEqual(result, output)
+        self.assertIs(result.serializer, output.serializer)
+
+    def test_return_list(self):
+        """
+        camelize() should convert keys in all objects contained in an instance
+        of rest_framework.utils.serializer_helpers.ReturnList and keep the same serializer.
+        """
+        fake_serializer_instance = (42,)
+
+        input = ReturnList([{"title_display": 1}, {"title_field": 2}], serializer=fake_serializer_instance)
+        output = ReturnList([{"titleDisplay": 1}, {"titleField": 2}], serializer=fake_serializer_instance)
+
+        result = camelize(input)
+        self.assertEqual(result, output)
+        self.assertIs(result.serializer, output.serializer)
+
 
 class CamelToUnderscoreTestCase(TestCase):
     def test_camel_to_under_dict(self):
@@ -130,6 +163,34 @@ class CamelToUnderscoreTestCase(TestCase):
         result = underscorize(input)
         self.assertEqual(result, output)
 
+    def test_return_dict(self):
+        """
+        underscorize() should convert keys in an instance of rest_framework.utils.serializer_helpers.ReturnDict
+        and keep the same serializer.
+        """
+        fake_serializer_instance = (42,)
+
+        input = ReturnDict([("titleDisplay", 1), ("titleField", 2)], serializer=fake_serializer_instance)
+        output = ReturnDict([("title_display", 1), ("title_field", 2)], serializer=fake_serializer_instance)
+
+        result = underscorize(input)
+        self.assertEqual(result, output)
+        self.assertIs(result.serializer, output.serializer)
+
+    def test_return_list(self):
+        """
+        underscorize() should convert keys in all objects contained in an instance
+        of rest_framework.utils.serializer_helpers.ReturnList and keep the same serializer.
+        """
+        fake_serializer_instance = (42,)
+
+        input = ReturnList([{"titleDisplay": 1}, {"titleField": 2}], serializer=fake_serializer_instance)
+        output = ReturnList([{"title_display": 1}, {"title_field": 2}], serializer=fake_serializer_instance)
+
+        result = underscorize(input)
+        self.assertEqual(result, output)
+        self.assertIs(result.serializer, output.serializer)
+
 
 class CompatibilityTest(TestCase):
     def test_compatibility(self):
@@ -139,3 +200,26 @@ class CompatibilityTest(TestCase):
             "a_tuple": ("one_two", 3)
         }
         self.assertEqual(underscorize(camelize(input)), input)
+
+    def test_compatibility_return_collections(self):
+        """
+        When the input with ReturnDict and ReturnList collections is processed by camelize() and then by underscorize(),
+        the result should be same. Serializers should be preserved in all nested ReturnDict and ReturnList collections.
+        """
+        fake_serializer_instance_1 = (42,)
+        fake_serializer_instance_2 = (42,)
+        fake_serializer_instance_3 = (42,)
+        input = ReturnDict([
+            ("title_display", 1),
+            ("a_list", ReturnList(
+                [1, "two_three", ReturnDict([("threee_four", 5)], serializer=fake_serializer_instance_3)],
+                serializer=fake_serializer_instance_2)
+             ),
+            ("a_tuple", ("one_two", 3))
+        ], serializer=fake_serializer_instance_1)
+
+        result = underscorize(camelize(input))
+        self.assertEqual(result, input)
+        self.assertIs(result.serializer, input.serializer)
+        self.assertIs(result['a_list'].serializer, input['a_list'].serializer)
+        self.assertIs(result['a_list'][2].serializer, input['a_list'][2].serializer)


### PR DESCRIPTION
These collections are defined in `rest_framework.utils.serializer_helpers` module and used by default serializers in Django REST framework. Without support for these collections, the library is not able to properly handle output of serializers.

This pull request is very similar to #1, however I have also added support for ReturnList collection. My changes should be more performant, since I do not copy the entire collection just to be cleared afterwards, but I rely on knowledge of internal structure of these collections.

I wanted to check types using `isinstance` instead of using `type(data) in (dict, OrderedDict)`, but then I noticed a recent change of this check in 527fa12 - is there any specific reason for exact type checking?