### PR TITLE
fix bad (i.e. too strict) type checking

### DIFF
--- a/rest_camel/util.py
+++ b/rest_camel/util.py
@@ -55,31 +55,27 @@ def underscore_key(key):
 
 
 def camelize(data):
-    data_type = type(data)
-
-    if data_type in (dict, OrderedDict):
-        new_dict = data_type()
-        for k, v in data.items():
-            new_dict[camelize_key(k, False)] = camelize(v)
+    if isinstance(data, (dict, OrderedDict)):
+        new_dict = OrderedDict()
+        for key, value in data.items():
+            new_dict[camelize_key(key, False)] = camelize(value)
 
         return new_dict
 
-    if data_type in (list, tuple):
-        return data_type(camelize(x) for x in data)
+    if isinstance(data, (list, tuple)):
+        return type(data)([camelize(x) for x in data])
 
     return data
 
 
 def underscorize(data):
-    data_type = type(data)
-
-    if data_type in (data, dict):
-        new_dict = data_type()
+    if isinstance(data, dict):
+        new_dict = type(data)()
         for key, value in data.items():
             new_dict[underscore_key(key)] = underscorize(value)
         return new_dict
 
-    if data_type in (list, tuple):
+    if isinstance(data, (list, tuple)):
         return type(data)(underscorize(x) for x in data)
 
     return data

--- a/tests.py
+++ b/tests.py
@@ -1,9 +1,30 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from collections import OrderedDict
 from unittest.case import TestCase
 
 from rest_camel.util import camelize, underscorize
+
+
+class MockReturnDict(OrderedDict):
+    """
+    Simulate Django Rest Framework's ReturnDict class.
+
+    Using this mock class is necessary so you don't have to load a lot more
+    configuration baggage to get a "real" instance of a ReturnDict.
+    """
+    def __init__(self, *args, **kwargs):
+        super(MockReturnDict, self).__init__(*args, **kwargs)
+
+    def copy(self):
+        return MockReturnDict(self)
+
+    def __repr__(self):
+        return dict.__repr__(self)
+
+    def __reduce__(self):
+        return (dict, (dict(self),))
 
 
 class UnderscoreToCamelTestCase(TestCase):
@@ -71,6 +92,16 @@ class UnderscoreToCamelTestCase(TestCase):
             "1": 1
         }
         self.assertEqual(camelize(input), output)
+
+    def test_under_to_camel_drf_ReturnDict(self):
+        input = MockReturnDict(
+            {"title_display": 1},
+        )
+        output = {
+            "titleDisplay": 1,
+        }
+        result = camelize(input)
+        self.assertEqual(result, output)
 
 
 class CamelToUnderscoreTestCase(TestCase):


### PR DESCRIPTION
This resolves an issue where `ReturnDict` objects returned from DRF serializers would not be correctly camelized, instead passing through a response with the original unmodified snake_case keys.

Note to future editors: `type` checking is too specific here because it does not account for class inheritance. In this case, `ReturnDict` is a subclass of `OrderedDict`, but `type` does not recognize that.